### PR TITLE
Updates from template

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -21,6 +21,12 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@main
 
+      # This makes it easier to push changes back to the PR
+      - name: "Checkout w/ gh"
+        run: gh pr checkout ${{ github.event.pull_request.number}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v2
 
@@ -40,15 +46,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Confirm"
+      - name: "Commit if Necessary"
         run: |
           if [[ "$(basename "$(git rev-parse --show-toplevel)")" != *'terraform-aws-template'* ]]; then
             echo "Setting core.fileMode to false to avoid false positives in documentation check."
             git config core.fileMode false
             if [[ -n $(git status --porcelain) ]]; then
-              echo "Documentation is not up to date. Run ./scripts/document.sh"
-              git status -v
-              git diff
-              exit 1
+              echo "Documentation is not up to date. Comitting updates"
+
+              git add README.md
+              git config user.name "${GITHUB_USERNAME}"
+              git config user.email "${GITHUB_USERNAME}@users.noreply.github.com"
+              git commit -m "Running document script"
+              git push
             fi
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USERNAME: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Use this URL for the source of the module. See the usage examples below for more details.
 
 ```hcl
-github.com/pbs/terraform-aws-efs-module?ref=0.1.3
+github.com/pbs/terraform-aws-efs-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -22,7 +22,7 @@ Integrate this module like so:
 
 ```hcl
 module "efs" {
-  source = "github.com/pbs/terraform-aws-efs-module?ref=0.1.3"
+  source = "github.com/pbs/terraform-aws-efs-module?ref=x.y.z"
 
   # Tagging Parameters
   organization = var.organization
@@ -46,7 +46,7 @@ module "efs" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.1.3`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 


### PR DESCRIPTION
- Bump aws from 4.67.0 to 5.4.0
- Update README for new release: 0.0.17
- Allowing document script to be run in CI
- Update README for new release: 0.0.18
